### PR TITLE
configure nextauth

### DIFF
--- a/motherhood_journey/src/shared/lib/auth.ts
+++ b/motherhood_journey/src/shared/lib/auth.ts
@@ -1,0 +1,79 @@
+import type { NextAuthConfig} from "next-auth";
+import CredentialsProvider from "next-auth/providers/credentials";
+
+export const authOptions: NextAuthConfig = {
+  providers: [
+    CredentialsProvider({
+      name: "Credentials",
+
+      credentials: {
+        phone: { label: "Phone", type: "phone" },
+        password: { label: "Password", type: "password" },
+      },
+
+      async authorize(credentials) {
+        try {
+          const res = await fetch(
+            `${process.env.NEXT_PUBLIC_API_URL}/auth/login`,
+            {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({
+                phone: credentials?.phone,
+                password: credentials?.password,
+              }),
+            }
+          );
+
+          
+          if (!res.ok) {
+            console.warn("login failed");
+            return null;
+          }
+
+          const user = await res.json();
+
+          return user;
+        } catch (error) {
+          console.error("Login error:", error);
+          return null;
+        }
+      },
+    }),
+    
+  ],
+
+   session:{
+    strategy:"jwt",
+   },
+
+   callbacks: {
+    async jwt({ token, user}){
+      if(user){
+        token.accessToken = user.token;
+        token.role = user.role;
+        token.facilityId = user.facilityId;
+        token.geoScopeIds = user.geoScopeIds;
+        token.canExport = user.canExport;
+        token.canPushHmis = user.canPushHmis;
+      }
+      return token;
+    },
+     async session({ session, token }) {
+      session.user.accessToken = token.accessToken;
+      session.user.role = token.role;
+      session.user.facilityId = token.facilityId;
+      session.user.geoScopeIds = token.geoScopeIds;
+      session.user.canExport = token.canExport;
+      session.user.canPushHmis = token.canPushHmis;
+
+     return session;
+   },
+
+    
+   },
+
+   
+};

--- a/motherhood_journey/src/shared/lib/auth.ts
+++ b/motherhood_journey/src/shared/lib/auth.ts
@@ -7,16 +7,19 @@ export const authOptions: NextAuthConfig = {
       name: "Credentials",
 
       credentials: {
-        phone: { label: "Phone", type: "phone" },
+        phone: { label: "Phone", type: "tel" },
         password: { label: "Password", type: "password" },
       },
 
       async authorize(credentials) {
         try {
+          const controller = new AbortController();
+          const timeoutId = setTimeout(() => controller.abort(), 10000);
           const res = await fetch(
             `${process.env.NEXT_PUBLIC_API_URL}/auth/login`,
             {
               method: "POST",
+              signal: controller.signal,
               headers: {
                 "Content-Type": "application/json",
               },
@@ -26,6 +29,7 @@ export const authOptions: NextAuthConfig = {
               }),
             }
           );
+          clearTimeout(timeoutId);
 
           
           if (!res.ok) {
@@ -34,6 +38,16 @@ export const authOptions: NextAuthConfig = {
           }
 
           const user = await res.json();
+          if(
+            !user ||
+            typeof user !== "object" ||
+            typeof user.token !== "string" ||
+            user.token.length === 0
+          ) {
+            console.warn("login response missing token");
+            return null;
+          }
+          
 
           return user;
         } catch (error) {

--- a/motherhood_journey/src/shared/types/auth.ts
+++ b/motherhood_journey/src/shared/types/auth.ts
@@ -33,7 +33,9 @@ declare module "next-auth/jwt" {
     canExport?: boolean;
     canPushHmis?: boolean;
   }
-}export type SignInPayload = {
+}
+
+export type SignInPayload = {
 	phone: string;
 	password: string;
 };

--- a/motherhood_journey/src/shared/types/auth.ts
+++ b/motherhood_journey/src/shared/types/auth.ts
@@ -1,0 +1,12 @@
+import "next-auth";
+
+declare module "next-auth" {
+  interface User {
+    token?: string;
+    role?: string;
+    facilityId?: number;
+    geoScopeIds?: number[];
+    canExport?: boolean;
+    canPushHmis?: boolean;
+  }
+}

--- a/motherhood_journey/src/shared/types/auth.ts
+++ b/motherhood_journey/src/shared/types/auth.ts
@@ -1,8 +1,32 @@
 import "next-auth";
+import { DefaultSession } from "next-auth";
+import "next-auth/jwt";
 
 declare module "next-auth" {
   interface User {
     token?: string;
+    role?: string;
+    facilityId?: number;
+    geoScopeIds?: number[];
+    canExport?: boolean;
+    canPushHmis?: boolean;
+  }
+
+  interface Session {
+    user: {
+      accessToken?: string;
+      role?: string;
+      facilityId?: number;
+      geoScopeIds?: number[];
+      canExport?: boolean;
+      canPushHmis?: boolean;
+    } & DefaultSession["user"];
+  }
+}
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    accessToken?: string;
     role?: string;
     facilityId?: number;
     geoScopeIds?: number[];


### PR DESCRIPTION
This PR sets up authentication using NextAuth with a CredentialsProvider (phone & password).

##  Changes

- Added NextAuth configuration with CredentialsProvider  
- Implemented JWT and session callbacks to handle user role, facility, and permissions  
- Extended TypeScript types for custom auth fields  
- Added API placeholder for `/auth/login`   
- Configured environment variables for auth setup 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authentication system configured with phone and password login via NextAuth
  * Session management with JWT token support
  * User authorization fields (role, facility access, permissions) properly integrated

<!-- end of auto-generated comment: release notes by coderabbit.ai -->