### PR TITLE
Hide shell chrome on login route

### DIFF
--- a/src/shared/components/layout/PortalShell.tsx
+++ b/src/shared/components/layout/PortalShell.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState } from "react";
 import type { ReactNode } from "react";
+import { usePathname } from "next/navigation";
 
 import { MobileNav } from "@/shared/components/layout/MobileNav";
 import { Sidebar } from "@/shared/components/layout/Sidebar";
@@ -20,6 +21,9 @@ export function PortalShell({
   fallbackRole,
   previewRole,
 }: PortalShellProps) {
+  const pathname = usePathname();
+  const isLoginRoute = pathname === "/login";
+
   // Always render the shell at the root layout. The previous module-scoped
   // global guard caused the shell to be skipped in some dev hot-reload
   // scenarios (leaving only children rendered). Removing the guard keeps the
@@ -45,19 +49,25 @@ export function PortalShell({
   }, []);
 
   return (
-    <div className="flex min-h-screen bg-[#F8FBFB] print:bg-white">
-      <SkipLink />
-      <Sidebar fallbackRole={fallbackRole} previewRole={runtimePreviewRole ?? previewRole} />
-
-      <div className="flex min-h-screen min-w-0 flex-1 flex-col">
-        <TopBar fallbackRole={fallbackRole} previewRole={runtimePreviewRole ?? previewRole} />
-
-        <main id="main-content" className="flex-1 px-4 py-6 pb-24 print:px-0 print:py-0 print:pb-0 sm:px-6 lg:px-8 lg:pb-8">
-          {children}
-        </main>
-
-        <MobileNav fallbackRole={fallbackRole} previewRole={runtimePreviewRole ?? previewRole} />
+    isLoginRoute ? (
+      <div className="min-h-screen bg-[#F8FBFB] print:bg-white">
+        {children}
       </div>
-    </div>
+    ) : (
+      <div className="flex min-h-screen bg-[#F8FBFB] print:bg-white">
+        <SkipLink />
+        <Sidebar fallbackRole={fallbackRole} previewRole={runtimePreviewRole ?? previewRole} />
+
+        <div className="flex min-h-screen min-w-0 flex-1 flex-col">
+          <TopBar fallbackRole={fallbackRole} previewRole={runtimePreviewRole ?? previewRole} />
+
+          <main id="main-content" className="flex-1 px-4 py-6 pb-24 print:px-0 print:py-0 print:pb-0 sm:px-6 lg:px-8 lg:pb-8">
+            {children}
+          </main>
+
+          <MobileNav fallbackRole={fallbackRole} previewRole={runtimePreviewRole ?? previewRole} />
+        </div>
+      </div>
+    )
   );
 }


### PR DESCRIPTION
This PR hides the global shell chrome on the /login route only, so the login form renders full-screen without affecting other pages.\n\nReview request: @Derrick-MUGISHA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Login page now displays a simplified layout without the sidebar, top navigation bar, and mobile navigation, providing a cleaner authentication experience.
  * All other pages maintain the standard application shell with full navigation components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SheCanCODE-Capstone-Projects/MotherHood_Journey_Frontend/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->