### PR TITLE
Integrate Government Reports API

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "dev",
+			"type": "shell",
+			"command": "npm",
+			"args": [
+				"run",
+				"dev"
+			],
+			"isBackground": true,
+			"problemMatcher": [],
+			"group": "build"
+		}
+	]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -113,7 +113,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -861,7 +860,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2668,7 +2666,6 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -4971,7 +4968,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4982,7 +4978,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4993,7 +4988,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -5094,7 +5088,6 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -5640,7 +5633,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6230,7 +6222,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -7461,7 +7452,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7647,7 +7637,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7971,7 +7960,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -8801,7 +8789,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.19.tgz",
       "integrity": "sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -8883,7 +8870,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.29.2"
       },
@@ -12498,7 +12484,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
       "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -12753,7 +12738,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12763,7 +12747,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -12776,7 +12759,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.75.0.tgz",
       "integrity": "sha512-Ovv94H+0p3sJ7B9B5QxPuCP1u8V/cHuVGyH55cSwodYDtoJwK+fqk3vjfIgSX59I2U/bU4z0nRJ9HMLpNiWEmw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -12819,15 +12801,13 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -12965,8 +12945,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -14269,7 +14248,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14535,7 +14513,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15248,7 +15225,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/app/(government)/reports/[reportId]/page.tsx
+++ b/src/app/(government)/reports/[reportId]/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useParams, useRouter } from "next/navigation";
-import { useState } from "react";
 import {
   BarChart,
   Bar,
@@ -18,7 +17,6 @@ import {
   ArrowLeft,
   Download,
   RefreshCw,
-  Upload,
   AlertCircle,
   CheckCircle,
   Clock,
@@ -28,7 +26,26 @@ import {
 
 import { useReports, getReportTypeLabel, getStatusLabel } from "@/hooks/useReports";
 import type { ReportStatus } from "@/shared/types/report";
-import { useAuth } from "@/shared/hooks/useAuth";
+
+type VaccinationCoverageReportData = {
+  byVaccineType: Array<{ vaccineType: string; coverage: number; target: number }>;
+};
+
+type AncAttendanceReportData = {
+  monthlyAttendance: Array<{ month: string; attendance: number }>;
+};
+
+type BirthRegistrationReportData = {
+  byDistrict: Array<{ district: string; registrations: number }>;
+};
+
+type MaternalHealthReportData = {
+  stats: {
+    maternalMortalityProxy: number;
+    ancCoverage: number;
+    institutionalDeliveryRate: number;
+  };
+};
 
 // Status badge colors
 const statusConfig: Record<
@@ -287,31 +304,7 @@ export default function ReportDetailPage() {
   const params = useParams();
   const router = useRouter();
   const reportId = params.reportId as string;
-  const { report, loading, error, pushing, pushToHmis } = useReports(reportId);
-  const { currentUser } = useAuth();
-  const [pushMessage, setPushMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
-
-  // Check if user is government role (MOH_ADMIN)
-  const isMohAdmin = currentUser?.role === "government";
-  const showPushButton = isMohAdmin && report && (report.status === "NOT_PUSHED" || report.status === "FAILED");
-
-  const handlePushToHmis = async () => {
-    try {
-      const result = await pushToHmis();
-      setPushMessage({
-        type: result.success ? "success" : "error",
-        text: result.message,
-      });
-      
-      // Clear message after 5 seconds
-      setTimeout(() => setPushMessage(null), 5000);
-    } catch (err) {
-      setPushMessage({
-        type: "error",
-        text: err instanceof Error ? err.message : "An error occurred",
-      });
-    }
-  };
+  const { report, loading, error, refetch } = useReports(reportId);
 
   const formatDate = (dateStr: string) => {
     return new Date(dateStr).toLocaleDateString("en-US", {
@@ -319,6 +312,17 @@ export default function ReportDetailPage() {
       month: "short",
       day: "numeric",
     });
+  };
+
+  const handleExport = () => {
+    const payload = JSON.stringify(report, null, 2);
+    const blob = new Blob([payload], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `${report.title.replaceAll(" ", "-").toLowerCase()}.json`;
+    anchor.click();
+    URL.revokeObjectURL(url);
   };
 
   if (loading) {
@@ -356,6 +360,11 @@ export default function ReportDetailPage() {
       </div>
     );
   }
+
+  const vaccinationData = report.reportType === "VACCINATION_COVERAGE" ? (report.data as VaccinationCoverageReportData) : null;
+  const ancData = report.reportType === "ANC_ATTENDANCE" ? (report.data as AncAttendanceReportData) : null;
+  const birthData = report.reportType === "BIRTH_REGISTRATION" ? (report.data as BirthRegistrationReportData) : null;
+  const maternalData = report.reportType === "MATERNAL_HEALTH" ? (report.data as MaternalHealthReportData) : null;
 
   return (
     <div className="space-y-6">
@@ -402,37 +411,21 @@ export default function ReportDetailPage() {
         {/* Action Buttons */}
         <div className="flex gap-3">
           <button
-            onClick={() => {}}
+            onClick={handleExport}
             className="flex items-center gap-2 rounded-xl border border-[#CFE3E9] bg-white px-4 py-2 text-sm font-medium text-[#194D56] hover:bg-[#E8F2F4]"
           >
             <Download className="h-4 w-4" />
             Export
           </button>
-          {showPushButton && (
-            <button
-              onClick={handlePushToHmis}
-              disabled={pushing}
-              className="flex items-center gap-2 rounded-xl bg-[#1F7280] px-4 py-2 text-sm font-medium text-white hover:bg-[#1A6270] disabled:opacity-50"
-            >
-              <Upload className={`h-4 w-4 ${pushing ? "animate-spin" : ""}`} />
-              {pushing ? "Pushing..." : "Push to HMIS"}
-            </button>
-          )}
+          <button
+            onClick={() => refetch()}
+            className="flex items-center gap-2 rounded-xl bg-[#1F7280] px-4 py-2 text-sm font-medium text-white hover:bg-[#1A6270]"
+          >
+            <RefreshCw className="h-4 w-4" />
+            Refresh
+          </button>
         </div>
       </div>
-
-      {/* Push Message */}
-      {pushMessage && (
-        <div
-          className={`rounded-xl p-4 ${
-            pushMessage.type === "success"
-              ? "bg-green-50 text-green-800 border border-green-200"
-              : "bg-red-50 text-red-800 border border-red-200"
-          }`}
-        >
-          {pushMessage.text}
-        </div>
-      )}
 
       {/* Content based on report type */}
       {report.reportType === "VACCINATION_COVERAGE" && (
@@ -441,20 +434,20 @@ export default function ReportDetailPage() {
             <StatCard
               label="Average Coverage"
               value={`${(
-                (report.data as any).byVaccineType.reduce(
-                  (sum: number, item: { coverage: number }) => sum + item.coverage,
-                  0
-                ) / (report.data as any).byVaccineType.length
+                (vaccinationData?.byVaccineType.reduce(
+                  (sum: number, item) => sum + item.coverage,
+                  0,
+                ) ?? 0) / Math.max(vaccinationData?.byVaccineType.length ?? 1, 1)
               ).toFixed(1)}%`}
               color="#1F7280"
             />
             <StatCard
               label="Vaccine Types Tracked"
-              value={(report.data as any).byVaccineType.length}
+              value={vaccinationData?.byVaccineType.length ?? 0}
               color="#10B981"
             />
           </div>
-          <VaccinationCoverageChart data={(report.data as any).byVaccineType} />
+          <VaccinationCoverageChart data={vaccinationData?.byVaccineType ?? []} />
         </>
       )}
 
@@ -463,33 +456,24 @@ export default function ReportDetailPage() {
           <div className="grid gap-4 md:grid-cols-3">
             <StatCard
               label="Total Attendance"
-              value={(report.data as any).monthlyAttendance.reduce(
-                (sum: number, item: { attendance: number }) => sum + item.attendance,
-                0
-              ).toLocaleString()}
+              value={(ancData?.monthlyAttendance.reduce((sum: number, item) => sum + item.attendance, 0) ?? 0).toLocaleString()}
               color="#1F7280"
             />
             <StatCard
               label="Average Monthly"
               value={Math.round(
-                (report.data as any).monthlyAttendance.reduce(
-                  (sum: number, item: { attendance: number }) => sum + item.attendance,
-                  0
-                ) / (report.data as any).monthlyAttendance.length
+                (ancData?.monthlyAttendance.reduce((sum: number, item) => sum + item.attendance, 0) ?? 0) /
+                  Math.max(ancData?.monthlyAttendance.length ?? 1, 1)
               ).toLocaleString()}
               color="#10B981"
             />
             <StatCard
               label="Peak Month"
-              value={Math.max(
-                ...(report.data as any).monthlyAttendance.map(
-                  (item: { attendance: number }) => item.attendance
-                )
-              ).toLocaleString()}
+              value={Math.max(...(ancData?.monthlyAttendance.map((item) => item.attendance) ?? [0])).toLocaleString()}
               color="#3B82F6"
             />
           </div>
-          <AncAttendanceChart data={(report.data as any).monthlyAttendance} />
+          <AncAttendanceChart data={ancData?.monthlyAttendance ?? []} />
         </>
       )}
 
@@ -498,34 +482,27 @@ export default function ReportDetailPage() {
           <div className="grid gap-4 md:grid-cols-3">
             <StatCard
               label="Total Registrations"
-              value={(report.data as any).byDistrict.reduce(
-                (sum: number, item: { registrations: number }) => sum + item.registrations,
-                0
-              ).toLocaleString()}
+              value={(birthData?.byDistrict.reduce((sum: number, item) => sum + item.registrations, 0) ?? 0).toLocaleString()}
               color="#1F7280"
             />
             <StatCard
               label="Districts Covered"
-              value={(report.data as any).byDistrict.length}
+              value={birthData?.byDistrict.length ?? 0}
               color="#10B981"
             />
             <StatCard
               label="Highest District"
-              value={Math.max(
-                ...(report.data as any).byDistrict.map(
-                  (item: { registrations: number }) => item.registrations
-                )
-              ).toLocaleString()}
+              value={Math.max(...(birthData?.byDistrict.map((item) => item.registrations) ?? [0])).toLocaleString()}
               color="#3B82F6"
             />
           </div>
-          <BirthRegistrationChart data={(report.data as any).byDistrict} />
+          <BirthRegistrationChart data={birthData?.byDistrict ?? []} />
         </>
       )}
 
       {report.reportType === "MATERNAL_HEALTH" && (
         <>
-          <MaternalHealthStats stats={(report.data as any).stats} />
+          <MaternalHealthStats stats={maternalData?.stats ?? { maternalMortalityProxy: 0, ancCoverage: 0, institutionalDeliveryRate: 0 }} />
           {/* Additional info card */}
           <div className="rounded-2xl border bg-white p-5 shadow-sm" style={{ borderColor: "#CFE3E9" }}>
             <h3 className="mb-3 text-base font-semibold" style={{ color: "#194D56" }}>
@@ -539,7 +516,7 @@ export default function ReportDetailPage() {
                 <div>
                   <p className="text-sm font-medium text-[#194D56]">ANC Coverage Target</p>
                   <p className="text-xs text-[#5B8784]">
-                    {(report.data as any).stats.ancCoverage >= 85 ? "Met" : "Below target"} (Target: 85%)
+                    {(maternalData?.stats.ancCoverage ?? 0) >= 85 ? "Met" : "Below target"} (Target: 85%)
                   </p>
                 </div>
               </div>
@@ -550,7 +527,7 @@ export default function ReportDetailPage() {
                 <div>
                   <p className="text-sm font-medium text-[#194D56]">Institutional Delivery</p>
                   <p className="text-xs text-[#5B8784]">
-                    {(report.data as any).stats.institutionalDeliveryRate >= 90 ? "Excellent" : "Needs improvement"} (Target: 90%)
+                    {(maternalData?.stats.institutionalDeliveryRate ?? 0) >= 90 ? "Excellent" : "Needs improvement"} (Target: 90%)
                   </p>
                 </div>
               </div>

--- a/src/app/(government)/reports/[reportId]/page.tsx
+++ b/src/app/(government)/reports/[reportId]/page.tsx
@@ -307,7 +307,13 @@ export default function ReportDetailPage() {
   const { report, loading, error, refetch } = useReports(reportId);
 
   const formatDate = (dateStr: string) => {
-    return new Date(dateStr).toLocaleDateString("en-US", {
+    const date = new Date(dateStr);
+
+    if (Number.isNaN(date.getTime())) {
+      return dateStr;
+    }
+
+    return date.toLocaleDateString("en-US", {
       year: "numeric",
       month: "short",
       day: "numeric",
@@ -393,7 +399,7 @@ export default function ReportDetailPage() {
             </span>
             <span>
               <span className="font-semibold">Period:</span>{" "}
-              {formatDate(report.periodStart)} - {formatDate(report.periodEnd)}
+              {report.period ?? `${formatDate(report.periodStart)} - ${formatDate(report.periodEnd)}`}
             </span>
             {report.facilityName && (
               <span>
@@ -434,16 +440,16 @@ export default function ReportDetailPage() {
             <StatCard
               label="Average Coverage"
               value={`${(
-                (vaccinationData?.byVaccineType.reduce(
+                ((vaccinationData?.byVaccineType ?? []).reduce(
                   (sum: number, item) => sum + item.coverage,
                   0,
-                ) ?? 0) / Math.max(vaccinationData?.byVaccineType.length ?? 1, 1)
+                ) ?? 0) / Math.max(vaccinationData?.byVaccineType?.length ?? 1, 1)
               ).toFixed(1)}%`}
               color="#1F7280"
             />
             <StatCard
               label="Vaccine Types Tracked"
-              value={vaccinationData?.byVaccineType.length ?? 0}
+              value={vaccinationData?.byVaccineType?.length ?? 0}
               color="#10B981"
             />
           </div>
@@ -456,20 +462,20 @@ export default function ReportDetailPage() {
           <div className="grid gap-4 md:grid-cols-3">
             <StatCard
               label="Total Attendance"
-              value={(ancData?.monthlyAttendance.reduce((sum: number, item) => sum + item.attendance, 0) ?? 0).toLocaleString()}
+              value={((ancData?.monthlyAttendance ?? []).reduce((sum: number, item) => sum + item.attendance, 0) ?? 0).toLocaleString()}
               color="#1F7280"
             />
             <StatCard
               label="Average Monthly"
               value={Math.round(
-                (ancData?.monthlyAttendance.reduce((sum: number, item) => sum + item.attendance, 0) ?? 0) /
-                  Math.max(ancData?.monthlyAttendance.length ?? 1, 1)
+                ((ancData?.monthlyAttendance ?? []).reduce((sum: number, item) => sum + item.attendance, 0) ?? 0) /
+                  Math.max(ancData?.monthlyAttendance?.length ?? 1, 1)
               ).toLocaleString()}
               color="#10B981"
             />
             <StatCard
               label="Peak Month"
-              value={Math.max(...(ancData?.monthlyAttendance.map((item) => item.attendance) ?? [0])).toLocaleString()}
+              value={Math.max(...((ancData?.monthlyAttendance ?? []).map((item) => item.attendance) ?? [0])).toLocaleString()}
               color="#3B82F6"
             />
           </div>
@@ -482,17 +488,17 @@ export default function ReportDetailPage() {
           <div className="grid gap-4 md:grid-cols-3">
             <StatCard
               label="Total Registrations"
-              value={(birthData?.byDistrict.reduce((sum: number, item) => sum + item.registrations, 0) ?? 0).toLocaleString()}
+              value={((birthData?.byDistrict ?? []).reduce((sum: number, item) => sum + item.registrations, 0) ?? 0).toLocaleString()}
               color="#1F7280"
             />
             <StatCard
               label="Districts Covered"
-              value={birthData?.byDistrict.length ?? 0}
+              value={birthData?.byDistrict?.length ?? 0}
               color="#10B981"
             />
             <StatCard
               label="Highest District"
-              value={Math.max(...(birthData?.byDistrict.map((item) => item.registrations) ?? [0])).toLocaleString()}
+              value={Math.max(...((birthData?.byDistrict ?? []).map((item) => item.registrations) ?? [0])).toLocaleString()}
               color="#3B82F6"
             />
           </div>

--- a/src/app/(government)/sync-log/page.tsx
+++ b/src/app/(government)/sync-log/page.tsx
@@ -12,7 +12,9 @@ import { queryKeys } from "@/shared/config/query-keys";
 import { useRole } from "@/shared/hooks/useRole";
 import { cn } from "@/shared/lib/utils";
 import {
+  getGovDeadLetterLogs,
   getGovSyncLogs,
+  getGovSyncStatus,
   retryGovSyncLog,
   type GovSyncLog,
   type GovSyncTargetSystem,
@@ -106,6 +108,18 @@ export default function GovernmentSyncLogPage() {
     refetchInterval: 30_000,
   });
 
+  const deadLetterQuery = useQuery({
+    queryKey: [...queryKeys.government.syncLogs, "dead-letter"],
+    queryFn: getGovDeadLetterLogs,
+    refetchInterval: 30_000,
+  });
+
+  const syncStatusQuery = useQuery({
+    queryKey: [...queryKeys.government.sync, "status"],
+    queryFn: getGovSyncStatus,
+    refetchInterval: 30_000,
+  });
+
   const retryMutation = useMutation({
     mutationFn: retryGovSyncLog,
     onMutate: async (id: string) => {
@@ -124,20 +138,25 @@ export default function GovernmentSyncLogPage() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.government.syncLogs });
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.government.sync, "status"] });
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.government.syncLogs, "dead-letter"] });
     },
   });
 
   const logs = useMemo(() => sortLogs(syncLogsQuery.data ?? []), [syncLogsQuery.data]);
+  const deadLetterLogs = useMemo(() => sortLogs(deadLetterQuery.data ?? []), [deadLetterQuery.data]);
   const canRetryDeadLetters =
     sessionRole === "MOH_ADMIN" || String(currentUser?.role ?? "").toUpperCase() === "MOH_ADMIN";
 
+  const statusCounts = useMemo(() => syncStatusQuery.data ?? {}, [syncStatusQuery.data]);
   const summary = useMemo(
     () => ({
-      total: logs.length,
-      inFlight: logs.filter((log) => log.status === "IN_FLIGHT").length,
-      failed: logs.filter((log) => log.status === "FAILED" || log.status === "DEAD_LETTER").length,
+      total: Object.values(statusCounts).reduce((accumulator, value) => accumulator + Number(value ?? 0), 0) || logs.length,
+      pending: Number(statusCounts.PENDING ?? 0),
+      inFlight: Number(statusCounts.IN_FLIGHT ?? 0),
+      deadLetter: Number(statusCounts.DEAD_LETTER ?? 0) || deadLetterLogs.length,
     }),
-    [logs],
+    [deadLetterLogs.length, logs.length, statusCounts],
   );
 
   const toggleError = (id: string) => {
@@ -178,14 +197,24 @@ export default function GovernmentSyncLogPage() {
           <p className="mt-2 text-3xl font-semibold" style={{ color: roleTheme.text }}>{summary.total}</p>
         </article>
         <article className="rounded-3xl border bg-white p-5 shadow-sm" style={{ borderColor: roleTheme.border }}>
-          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[#5B8784]">In flight</p>
-          <p className="mt-2 text-3xl font-semibold text-blue-700">{summary.inFlight}</p>
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[#5B8784]">Pending</p>
+          <p className="mt-2 text-3xl font-semibold text-blue-700">{summary.pending}</p>
         </article>
         <article className="rounded-3xl border bg-white p-5 shadow-sm" style={{ borderColor: roleTheme.border }}>
-          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[#5B8784]">Needs attention</p>
-          <p className="mt-2 text-3xl font-semibold text-amber-700">{summary.failed}</p>
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[#5B8784]">In flight</p>
+          <p className="mt-2 text-3xl font-semibold text-amber-700">{summary.inFlight}</p>
+        </article>
+        <article className="rounded-3xl border bg-white p-5 shadow-sm" style={{ borderColor: roleTheme.border }}>
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[#5B8784]">Dead letter</p>
+          <p className="mt-2 text-3xl font-semibold text-red-700">{summary.deadLetter}</p>
         </article>
       </section>
+
+      {syncStatusQuery.error || syncLogsQuery.error ? (
+        <div className="rounded-2xl border border-red-200 bg-red-50 px-5 py-4 text-sm text-red-700">
+          Unable to load one or more sync sources. Refresh to try again.
+        </div>
+      ) : null}
 
       <section className="overflow-hidden rounded-3xl border bg-white shadow-sm" style={{ borderColor: roleTheme.border }}>
         <div className="flex flex-wrap items-center justify-between gap-3 border-b px-5 py-4" style={{ borderColor: roleTheme.border }}>
@@ -202,7 +231,7 @@ export default function GovernmentSyncLogPage() {
         </div>
 
         <div className="overflow-x-auto">
-          <table className="min-w-[980px] w-full text-left text-sm">
+          <table className="w-full text-left text-sm" style={{ minWidth: 980 }}>
             <thead className="bg-slate-50 text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
               <tr>
                 <th className="px-5 py-4">ID</th>
@@ -289,6 +318,107 @@ export default function GovernmentSyncLogPage() {
 
         {!syncLogsQuery.isLoading && logs.length === 0 ? (
           <div className="px-5 py-12 text-center text-sm text-slate-500">No sync log entries found.</div>
+        ) : null}
+      </section>
+
+      <section className="overflow-hidden rounded-3xl border bg-white shadow-sm" style={{ borderColor: roleTheme.border }}>
+        <div className="flex flex-wrap items-center justify-between gap-3 border-b px-5 py-4" style={{ borderColor: roleTheme.border }}>
+          <div>
+            <h2 className="text-lg font-semibold" style={{ color: roleTheme.text }}>Dead-letter queue</h2>
+            <p className="mt-1 text-sm text-slate-500">Entries that exhausted retries and need manual intervention.</p>
+          </div>
+          {deadLetterQuery.error ? (
+            <div className="inline-flex items-center gap-2 rounded-full bg-red-50 px-3 py-1.5 text-sm font-medium text-red-700">
+              <AlertCircle className="size-4" />
+              Unable to load queue
+            </div>
+          ) : null}
+        </div>
+
+        <div className="overflow-x-auto">
+          <table className="w-full text-left text-sm" style={{ minWidth: 980 }}>
+            <thead className="bg-slate-50 text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+              <tr>
+                <th className="px-5 py-4">ID</th>
+                <th className="px-5 py-4">Created</th>
+                <th className="px-5 py-4">Target</th>
+                <th className="px-5 py-4">Sync type</th>
+                <th className="px-5 py-4">Retries</th>
+                <th className="px-5 py-4">Last error</th>
+                <th className="px-5 py-4 text-right">Action</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {deadLetterLogs.map((log) => {
+                const hasError = Boolean(log.lastErrorMessage);
+                const isExpanded = expandedErrors.has(log.id);
+                const retryingThisRow = retryMutation.isPending && retryMutation.variables === log.id;
+
+                return (
+                  <tr key={log.id} className="bg-red-50/40">
+                    <td className="px-5 py-4 font-mono text-xs text-slate-600" title={log.id}>
+                      {truncateUuid(log.id)}
+                    </td>
+                    <td className="px-5 py-4 whitespace-nowrap text-slate-700">
+                      {formatCreatedDate(log.createdAt)}
+                    </td>
+                    <td className="px-5 py-4">
+                      <span className={cn("inline-flex rounded-full px-3 py-1 text-xs font-semibold ring-1", getTargetSystemClassName(log.targetSystem))}>
+                        {log.targetSystem}
+                      </span>
+                    </td>
+                    <td className="px-5 py-4 font-medium text-slate-800">{log.syncType}</td>
+                    <td className="px-5 py-4 text-slate-700">{log.retryCount}</td>
+                    <td className="max-w-[320px] px-5 py-4 text-slate-600">
+                      {hasError ? (
+                        <button
+                          className="text-left text-sm leading-5 hover:text-slate-900"
+                          onClick={() => toggleError(log.id)}
+                          title={log.lastErrorMessage ?? undefined}
+                          type="button"
+                        >
+                          {isExpanded ? log.lastErrorMessage : truncateError(log.lastErrorMessage ?? "")}
+                          {log.lastErrorMessage && log.lastErrorMessage.length > ERROR_PREVIEW_LENGTH ? (
+                            <span className="ml-1 font-semibold text-[#1F7280]">
+                              {isExpanded ? "Show less" : "Expand"}
+                            </span>
+                          ) : null}
+                        </button>
+                      ) : (
+                        <span className="text-slate-400">None</span>
+                      )}
+                    </td>
+                    <td className="px-5 py-4 text-right">
+                      {canRetryDeadLetters ? (
+                        <Button
+                          className="h-8 rounded-full px-3"
+                          disabled={retryingThisRow}
+                          onClick={() => retryMutation.mutate(log.id)}
+                          size="sm"
+                        >
+                          <RotateCcw className={cn("size-3.5", retryingThisRow && "animate-spin")} />
+                          Retry
+                        </Button>
+                      ) : (
+                        <span className="text-slate-300">-</span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        {deadLetterQuery.isLoading ? (
+          <div className="flex items-center justify-center gap-2 px-5 py-12 text-sm text-slate-500">
+            <RefreshCcw className="size-4 animate-spin" />
+            Loading dead-letter queue
+          </div>
+        ) : null}
+
+        {!deadLetterQuery.isLoading && deadLetterLogs.length === 0 ? (
+          <div className="px-5 py-12 text-center text-sm text-slate-500">Dead-letter queue is empty.</div>
         ) : null}
       </section>
     </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,5 @@
-@import "tailwindcss";
-@import "tw-animate-css";
+@import "../../node_modules/tailwindcss/index.css";
+@import "../../node_modules/tw-animate-css/dist/tw-animate.css";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/src/app/reports/new/page.tsx
+++ b/src/app/reports/new/page.tsx
@@ -3,25 +3,89 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { CalendarDays, BarChart3, ArrowLeft } from "lucide-react";
+import { useMutation, useQuery } from "@tanstack/react-query";
 
 import { PageHeader } from "@/shared/components/layout";
 import { ROLE_THEMES } from "@/shared/config/rbac";
 import { useRole } from "@/shared/hooks/useRole";
+import { getReportTypeLabel } from "@/hooks/useReports";
+import { generateGovReport, getCurrentGovernmentProfile, type GovReportRequest } from "@/lib/api/government";
 
-const AVAILABLE_METRICS = [
-  "ANC coverage",
-  "Vaccination coverage",
-  "Facility attendance",
-  "Referral completion",
-  "Service request turnaround",
-  "Sync success rate",
+const REPORT_TYPES: GovReportRequest["reportType"][] = [
+  "VACCINATION_COVERAGE",
+  "ANC_ATTENDANCE",
+  "BIRTH_REGISTRATION",
+  "MATERNAL_HEALTH",
 ];
+
+const SCOPE_LEVELS = ["NATIONAL", "PROVINCE", "DISTRICT", "FACILITY"];
+
+const DEFAULT_AGGREGATES: Record<GovReportRequest["reportType"], string> = {
+  VACCINATION_COVERAGE: JSON.stringify({ byVaccineType: [{ vaccineType: "BCG", coverage: 92, target: 95 }] }, null, 2),
+  ANC_ATTENDANCE: JSON.stringify({ monthlyAttendance: [{ month: "Jan", attendance: 342 }] }, null, 2),
+  BIRTH_REGISTRATION: JSON.stringify({ byDistrict: [{ district: "Bugesera", registrations: 523 }] }, null, 2),
+  MATERNAL_HEALTH: JSON.stringify({ stats: { maternalMortalityProxy: 0.12, ancCoverage: 89.5, institutionalDeliveryRate: 91.2 } }, null, 2),
+};
 
 export default function NewCustomReportPage() {
   const router = useRouter();
   const { role } = useRole();
   const roleTheme = role === "government" ? ROLE_THEMES.government : ROLE_THEMES.facility_admin;
-  const [submitted, setSubmitted] = useState(false);
+  const profileQuery = useQuery({
+    queryKey: ["government", "me", "report-create"],
+    queryFn: getCurrentGovernmentProfile,
+  });
+  const [reportType, setReportType] = useState<GovReportRequest["reportType"]>("VACCINATION_COVERAGE");
+  const [period, setPeriod] = useState("2026-Q2");
+  const [scopeLevel, setScopeLevel] = useState("NATIONAL");
+  const [geoLocationId, setGeoLocationId] = useState("");
+  const [aggregatesJson, setAggregatesJson] = useState(DEFAULT_AGGREGATES.VACCINATION_COVERAGE);
+  const [error, setError] = useState<string | null>(null);
+
+  const generateMutation = useMutation({
+    mutationFn: generateGovReport,
+    onSuccess: (report) => {
+      router.push(`/reports/${report.id}`);
+    },
+    onError: (mutationError) => {
+      setError(mutationError instanceof Error ? mutationError.message : "Failed to generate report");
+    },
+  });
+
+  const currentProfile = profileQuery.data;
+
+  const handleReportTypeChange = (nextType: GovReportRequest["reportType"]) => {
+    setReportType(nextType);
+    setAggregatesJson(DEFAULT_AGGREGATES[nextType]);
+  };
+
+  const handleGenerate = () => {
+    setError(null);
+
+    let aggregates: Record<string, unknown>;
+
+    try {
+      aggregates = JSON.parse(aggregatesJson) as Record<string, unknown>;
+    } catch {
+      setError("Aggregates must be valid JSON.");
+      return;
+    }
+
+    const resolvedGeoLocationId = geoLocationId.trim() || currentProfile?.geoLocationId;
+
+    if (!resolvedGeoLocationId) {
+      setError("A geo location ID is required to generate a report.");
+      return;
+    }
+
+    generateMutation.mutate({
+      reportType,
+      period,
+      scopeLevel,
+      geoLocationId: resolvedGeoLocationId,
+      aggregates,
+    });
+  };
 
   return (
     <div className="space-y-6">
@@ -37,7 +101,7 @@ export default function NewCustomReportPage() {
 
       <PageHeader
         title="Create Custom Report"
-        subtitle="Choose metrics and a date range to generate a tailored report."
+        subtitle="Generate a backend-backed government report with your selected scope and aggregates."
       />
 
       <section className="rounded-2xl border-2 bg-white p-6" style={{ borderColor: roleTheme.border }}>
@@ -49,7 +113,8 @@ export default function NewCustomReportPage() {
               </label>
               <input
                 type="text"
-                defaultValue="Custom government report"
+                value={getReportTypeLabel(reportType)}
+                readOnly
                 className="w-full rounded-xl border px-4 py-3 text-sm outline-none"
                 style={{ borderColor: roleTheme.border }}
               />
@@ -57,68 +122,98 @@ export default function NewCustomReportPage() {
 
             <div>
               <label className="mb-2 block text-sm font-semibold" style={{ color: roleTheme.text }}>
-                Date range
+                Reporting period
               </label>
-              <div className="grid gap-3 sm:grid-cols-2">
-                <input
-                  type="date"
-                  defaultValue="2024-04-01"
-                  className="rounded-xl border px-4 py-3 text-sm outline-none"
-                  style={{ borderColor: roleTheme.border }}
-                />
-                <input
-                  type="date"
-                  defaultValue="2024-04-30"
-                  className="rounded-xl border px-4 py-3 text-sm outline-none"
-                  style={{ borderColor: roleTheme.border }}
-                />
-              </div>
+              <input
+                type="text"
+                value={period}
+                onChange={(event) => setPeriod(event.target.value)}
+                placeholder="2026-Q2"
+                className="w-full rounded-xl border px-4 py-3 text-sm outline-none"
+                style={{ borderColor: roleTheme.border }}
+              />
             </div>
 
             <div>
               <label className="mb-2 block text-sm font-semibold" style={{ color: roleTheme.text }}>
-                Delivery format
+                Scope level
               </label>
               <select
                 className="w-full rounded-xl border px-4 py-3 text-sm outline-none"
                 style={{ borderColor: roleTheme.border }}
-                defaultValue="pdf"
+                value={scopeLevel}
+                onChange={(event) => setScopeLevel(event.target.value)}
               >
-                <option value="pdf">PDF</option>
-                <option value="excel">Excel</option>
-                <option value="csv">CSV</option>
+                {SCOPE_LEVELS.map((level) => (
+                  <option key={level} value={level}>
+                    {level}
+                  </option>
+                ))}
               </select>
+            </div>
+
+            <div>
+              <label className="mb-2 block text-sm font-semibold" style={{ color: roleTheme.text }}>
+                Geo location ID
+              </label>
+              <input
+                type="text"
+                value={geoLocationId}
+                onChange={(event) => setGeoLocationId(event.target.value)}
+                placeholder={currentProfile?.geoLocationId ?? "Enter a geo location UUID"}
+                className="w-full rounded-xl border px-4 py-3 text-sm outline-none"
+                style={{ borderColor: roleTheme.border }}
+              />
             </div>
           </div>
 
           <div>
             <label className="mb-2 block text-sm font-semibold" style={{ color: roleTheme.text }}>
-              Metrics to include
+              Report type
             </label>
-            <div className="grid gap-3 sm:grid-cols-2">
-              {AVAILABLE_METRICS.map((metric) => (
+            <div className="grid gap-3">
+              {REPORT_TYPES.map((type) => (
                 <label
-                  key={metric}
+                  key={type}
                   className="flex items-center gap-3 rounded-xl border px-4 py-3 text-sm"
                   style={{ borderColor: roleTheme.border }}
                 >
-                  <input type="checkbox" defaultChecked={metric === "ANC coverage" || metric === "Vaccination coverage"} />
-                  <span>{metric}</span>
+                  <input
+                    type="radio"
+                    name="reportType"
+                    checked={reportType === type}
+                    onChange={() => handleReportTypeChange(type)}
+                  />
+                  <span>{getReportTypeLabel(type)}</span>
                 </label>
               ))}
             </div>
           </div>
         </div>
 
+        <div className="mt-6">
+          <label className="mb-2 block text-sm font-semibold" style={{ color: roleTheme.text }}>
+            Aggregates JSON
+          </label>
+          <textarea
+            value={aggregatesJson}
+            onChange={(event) => setAggregatesJson(event.target.value)}
+            rows={10}
+            className="w-full rounded-2xl border px-4 py-3 font-mono text-xs outline-none"
+            style={{ borderColor: roleTheme.border }}
+          />
+        </div>
+
         <div className="mt-6 flex flex-wrap items-center gap-3">
           <button
             type="button"
-            onClick={() => setSubmitted(true)}
+            onClick={handleGenerate}
+            disabled={generateMutation.isPending}
             className="inline-flex items-center gap-2 rounded-xl px-4 py-2 text-sm font-semibold text-white"
             style={{ backgroundColor: roleTheme.accent }}
           >
             <BarChart3 className="size-4" />
-            Generate Report
+            {generateMutation.isPending ? "Generating..." : "Generate Report"}
           </button>
           <button
             type="button"
@@ -131,9 +226,9 @@ export default function NewCustomReportPage() {
           </button>
         </div>
 
-        {submitted ? (
-          <p className="mt-4 rounded-xl border px-4 py-3 text-sm font-medium" style={{ borderColor: roleTheme.border, color: roleTheme.text }}>
-            Report configured successfully in demo mode. Connect the backend export endpoint to generate the file.
+        {error ? (
+          <p className="mt-4 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm font-medium text-red-800">
+            {error}
           </p>
         ) : null}
       </section>

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -1,17 +1,28 @@
 "use client";
 
+import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { useMemo } from "react";
 
 import { PageHeader } from "@/shared/components/layout";
 import { ROLE_THEMES } from "@/shared/config/rbac";
 import { useRole } from "@/shared/hooks/useRole";
-import { BarChart3, TrendingUp, Users, Heart, Download, Calendar } from "lucide-react";
+import { useReportList, getReportTypeLabel, getStatusLabel } from "@/hooks/useReports";
+import { AlertCircle, BarChart3, Calendar, Heart, RefreshCw, TrendingUp, Users, Download } from "lucide-react";
+
+const REPORT_TYPES = [
+  "VACCINATION_COVERAGE",
+  "ANC_ATTENDANCE",
+  "BIRTH_REGISTRATION",
+  "MATERNAL_HEALTH",
+] as const;
 
 export default function ReportsPage() {
   const router = useRouter();
   const { role } = useRole();
   const roleTheme = role === "government" ? ROLE_THEMES.government : ROLE_THEMES.facility_admin;
   const isGovernment = role === "government";
+  const { reports, loading, error } = useReportList();
 
   const handleCreateReport = () => {
     router.push("/reports/new");
@@ -21,54 +32,83 @@ export default function ReportsPage() {
     router.push("/reports/schedule");
   };
 
-  const reportCategories = [
-    {
-      id: 1,
-      name: "Maternal Health Summary",
-      icon: Heart,
-      metrics: isGovernment ? "2,456 mothers" : "156 mothers",
-      lastGenerated: "Apr 10, 2024",
-      frequency: "Monthly",
-    },
-    {
-      id: 2,
-      name: "Performance Dashboard",
-      icon: BarChart3,
-      metrics: isGovernment ? "98% completion rate" : "94% targets met",
-      lastGenerated: "Apr 12, 2024",
-      frequency: "Real-time",
-    },
-    {
-      id: 3,
-      name: "Staff Productivity",
-      icon: Users,
-      metrics: isGovernment ? "2,341 visits" : "89 visits",
-      lastGenerated: "Apr 11, 2024",
-      frequency: "Weekly",
-    },
-    {
-      id: 4,
-      name: "Trend Analysis",
-      icon: TrendingUp,
-      metrics: isGovernment ? "+12% YoY growth" : "+5% improvement",
-      lastGenerated: "Apr 10, 2024",
-      frequency: "Monthly",
-    },
-  ];
+  const summary = useMemo(() => {
+    const totals = reports.reduce(
+      (accumulator, report) => {
+        accumulator.total += 1;
+        accumulator.status[report.status] = (accumulator.status[report.status] ?? 0) + 1;
+        return accumulator;
+      },
+      {
+        total: 0,
+        status: {} as Record<string, number>,
+      },
+    );
 
-  const recentReports = [
-    { name: "Monthly Performance Report - March 2024", type: "PDF", size: "2.4 MB", date: "Apr 1, 2024", downloads: 45 },
-    { name: "Vaccination Coverage Report", type: "Excel", size: "1.2 MB", date: "Apr 5, 2024", downloads: 23 },
-    { name: "Staff Attendance Report - Q1 2024", type: "PDF", size: "890 KB", date: "Apr 8, 2024", downloads: 12 },
-    { name: "Maternal Health Indicators", type: "Excel", size: "1.8 MB", date: "Apr 10, 2024", downloads: 34 },
-  ];
+    return {
+      total: totals.total,
+      pushed: totals.status.PUSHED ?? 0,
+      queued: totals.status.QUEUED ?? 0,
+      failed: totals.status.FAILED ?? 0,
+    };
+  }, [reports]);
+
+  const sortedReports = useMemo(
+    () => [...reports].sort((left, right) => Date.parse(right.generatedAt) - Date.parse(left.generatedAt)),
+    [reports],
+  );
+
+  const reportCategories = REPORT_TYPES.map((type) => {
+    const latest = sortedReports.find((report) => report.reportType === type);
+    const count = reports.filter((report) => report.reportType === type).length;
+
+    return {
+      id: type,
+      name: getReportTypeLabel(type),
+      icon: type === "VACCINATION_COVERAGE" ? Heart : type === "ANC_ATTENDANCE" ? BarChart3 : type === "BIRTH_REGISTRATION" ? Users : TrendingUp,
+      metrics: `${count} generated`,
+      lastGenerated: latest
+        ? new Date(latest.generatedAt).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })
+        : "No reports yet",
+      frequency: latest?.period ?? "On demand",
+      reportId: latest?.id,
+    };
+  });
 
   return (
     <div className="space-y-6">
       <PageHeader
         title={isGovernment ? "National Reports" : "Reports"}
-        subtitle={isGovernment ? "National maternal health program reports and statistics." : "Facility performance and operational reports."}
+        subtitle={isGovernment ? "Backend-backed national maternal health analytics and HMIS reporting." : "Facility performance and operational reports."}
       />
+
+      <section className="grid gap-4 md:grid-cols-4">
+        {[
+          { label: "Reports", value: summary.total, icon: BarChart3 },
+          { label: "Pushed", value: summary.pushed, icon: TrendingUp },
+          { label: "Queued", value: summary.queued, icon: RefreshCw },
+          { label: "Failed", value: summary.failed, icon: AlertCircle },
+        ].map((stat) => {
+          const Icon = stat.icon;
+          return (
+            <div key={stat.label} className="rounded-2xl border-2 bg-white p-5" style={{ borderColor: roleTheme.border }}>
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.14em]" style={{ color: roleTheme.text }}>
+                    {stat.label}
+                  </p>
+                  <p className="mt-2 text-3xl font-bold" style={{ color: roleTheme.text }}>
+                    {stat.value}
+                  </p>
+                </div>
+                <div className="rounded-xl p-2" style={{ backgroundColor: roleTheme.accentSoft }}>
+                  <Icon className="size-5" style={{ color: roleTheme.accent }} />
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </section>
 
       {/* Report Categories */}
       <section>
@@ -77,7 +117,7 @@ export default function ReportsPage() {
           {reportCategories.map((category) => {
             const Icon = category.icon;
             return (
-              <div key={category.id} className="rounded-2xl border-2 p-5" style={{ borderColor: roleTheme.border }}>
+              <div key={category.id} className="rounded-2xl border-2 bg-white p-5" style={{ borderColor: roleTheme.border }}>
                 <div className="flex items-start justify-between">
                   <div className="flex-1">
                     <div className="flex items-center gap-3">
@@ -91,8 +131,19 @@ export default function ReportsPage() {
                       <span>📅 {category.lastGenerated}</span>
                       <span>🔄 {category.frequency}</span>
                     </div>
+                    {category.reportId ? (
+                      <Link href={`/reports/${category.reportId}`} className="mt-4 inline-flex text-sm font-semibold" style={{ color: roleTheme.accent }}>
+                        Open latest report
+                      </Link>
+                    ) : null}
                   </div>
-                  <button className="rounded-lg px-3 py-2 text-sm font-semibold" style={{ backgroundColor: roleTheme.accent, color: "white" }}>
+                  <button
+                    type="button"
+                    className="rounded-lg px-3 py-2 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-50"
+                    onClick={() => category.reportId && router.push(`/reports/${category.reportId}`)}
+                    style={{ backgroundColor: roleTheme.accent, color: "white" }}
+                    disabled={!category.reportId}
+                  >
                     View
                   </button>
                 </div>
@@ -109,30 +160,41 @@ export default function ReportsPage() {
           <div className="grid grid-cols-5 gap-4 rounded-2xl border-2 p-4 font-semibold text-sm" style={{ borderColor: roleTheme.border, backgroundColor: roleTheme.accentSoft, color: roleTheme.text }}>
             <div>Report Name</div>
             <div>Type</div>
-            <div>Size</div>
+            <div>Status</div>
             <div>Generated</div>
             <div className="text-center">Actions</div>
           </div>
-          {recentReports.map((report, idx) => (
-            <div key={idx} className="grid grid-cols-5 gap-4 rounded-2xl border p-4 items-center text-sm" style={{ borderColor: roleTheme.border }}>
-              <div className="font-medium" style={{ color: roleTheme.text }}>{report.name}</div>
-              <div style={{ color: roleTheme.text }}>{report.type}</div>
-              <div style={{ color: roleTheme.text }}>{report.size}</div>
-              <div style={{ color: roleTheme.text }}>{report.date}</div>
+          {sortedReports.slice(0, 4).map((report) => (
+            <div key={report.id} className="grid grid-cols-5 items-center gap-4 rounded-2xl border bg-white p-4 text-sm" style={{ borderColor: roleTheme.border }}>
+              <div className="font-medium" style={{ color: roleTheme.text }}>{report.title}</div>
+              <div style={{ color: roleTheme.text }}>{getReportTypeLabel(report.reportType)}</div>
+              <div style={{ color: roleTheme.text }}>{getStatusLabel(report.status)}</div>
+              <div style={{ color: roleTheme.text }}>{new Date(report.generatedAt).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}</div>
               <div className="flex justify-center gap-2">
-                <button className="rounded-lg p-2 hover:opacity-75" style={{ backgroundColor: roleTheme.accentSoft }}>
+                <Link href={`/reports/${report.id}`} className="rounded-lg p-2 hover:opacity-75" style={{ backgroundColor: roleTheme.accentSoft }}>
                   <Download className="size-4" style={{ color: roleTheme.accent }} />
-                </button>
+                </Link>
               </div>
             </div>
           ))}
+          {!loading && !sortedReports.length ? (
+            <div className="rounded-2xl border border-dashed p-8 text-center text-sm" style={{ borderColor: roleTheme.border, color: roleTheme.text }}>
+              No government reports have been generated yet.
+            </div>
+          ) : null}
         </div>
       </section>
+
+      {error ? (
+        <div className="rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+          Failed to load government reports: {error}
+        </div>
+      ) : null}
 
       {/* Generate Custom Report */}
       <section className="rounded-2xl border-2 p-6" style={{ borderColor: roleTheme.border, backgroundColor: roleTheme.accentSoft }}>
         <h3 className="text-lg font-semibold" style={{ color: roleTheme.text }}>Generate Custom Report</h3>
-        <p className="mt-2 text-sm" style={{ color: roleTheme.text }}>Create a customized report with specific metrics and date ranges for your needs.</p>
+        <p className="mt-2 text-sm" style={{ color: roleTheme.text }}>Create a backend-backed government report and store it in the reporting history.</p>
         <div className="mt-4 flex flex-wrap gap-3">
           <button
             type="button"

--- a/src/app/reports/schedule/page.tsx
+++ b/src/app/reports/schedule/page.tsx
@@ -115,7 +115,7 @@ export default function ScheduleReportPage() {
 
         {scheduled ? (
           <p className="mt-4 rounded-xl border px-4 py-3 text-sm font-medium" style={{ borderColor: roleTheme.border, color: roleTheme.text }}>
-            Schedule saved in demo mode. Connect the backend job scheduler to activate recurring delivery.
+            Schedule saved locally. Backend scheduling support is not exposed yet, so use Generate Report for now.
           </p>
         ) : null}
       </section>

--- a/src/app/visits/new/page.tsx
+++ b/src/app/visits/new/page.tsx
@@ -1,0 +1,5 @@
+import HealthWorkerNewVisitPage from "../../../health-worker/visits/new/page";
+
+export default function NewVisitPage() {
+  return <HealthWorkerNewVisitPage />;
+}

--- a/src/hooks/useReports.ts
+++ b/src/hooks/useReports.ts
@@ -3,7 +3,7 @@
 import { useQuery } from "@tanstack/react-query";
 import type { ReportStatus, ReportType } from "@/shared/types/report";
 
-import { getGovReport, getGovReportsByUser } from "@/lib/api/government";
+import { getCurrentGovernmentUserId, getGovReport, getGovReportsByUser } from "@/lib/api/government";
 
 /**
  * Custom hook for managing report data and operations
@@ -26,16 +26,26 @@ export function useReports(reportId: string) {
  * Hook to get all reports (for listing)
  */
 export function useReportList(userId?: string) {
+  const currentUserQuery = useQuery({
+    queryKey: ["government", "me", "report-user"],
+    queryFn: getCurrentGovernmentUserId,
+    enabled: !userId,
+  });
+
+  const resolvedUserId = userId ?? currentUserQuery.data ?? undefined;
+
   const reportListQuery = useQuery({
-    queryKey: ["government", "reports", "list", userId ?? "anonymous"],
-    queryFn: () => getGovReportsByUser(userId ?? ""),
-    enabled: Boolean(userId),
+    queryKey: ["government", "reports", "list", resolvedUserId ?? "anonymous"],
+    queryFn: () => getGovReportsByUser(resolvedUserId ?? ""),
+    enabled: Boolean(resolvedUserId),
   });
 
   return {
     reports: reportListQuery.data ?? [],
-    loading: reportListQuery.isLoading,
-    error: reportListQuery.error instanceof Error ? reportListQuery.error.message : null,
+    loading: currentUserQuery.isLoading || reportListQuery.isLoading,
+    error:
+      (currentUserQuery.error instanceof Error ? currentUserQuery.error.message : null) ??
+      (reportListQuery.error instanceof Error ? reportListQuery.error.message : null),
   };
 }
 

--- a/src/hooks/useReports.ts
+++ b/src/hooks/useReports.ts
@@ -1,212 +1,41 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
-import type { Report, ReportStatus, PushHmisResponse, ReportType } from "@/shared/types/report";
+import { useQuery } from "@tanstack/react-query";
+import type { ReportStatus, ReportType } from "@/shared/types/report";
 
-// Mock data for different report types
-const mockReports: Record<string, Report> = {
-  "rpt-vaccination-001": {
-    id: "rpt-vaccination-001",
-    reportType: "VACCINATION_COVERAGE",
-    status: "NOT_PUSHED",
-    title: "Vaccination Coverage Report - Q1 2024",
-    description: "Comprehensive vaccination coverage analysis across all facilities",
-    generatedAt: "2024-03-31T10:00:00Z",
-    periodStart: "2024-01-01T00:00:00Z",
-    periodEnd: "2024-03-31T23:59:59Z",
-    districtName: "Bugesera District",
-    data: {
-      byVaccineType: [
-        { vaccineType: "BCG", coverage: 92, target: 95 },
-        { vaccineType: "DPT-HepB-Hib", coverage: 88, target: 90 },
-        { vaccineType: "Polio", coverage: 91, target: 95 },
-        { vaccineType: "Pentavalent", coverage: 87, target: 90 },
-        { vaccineType: "Measles", coverage: 85, target: 90 },
-        { vaccineType: "TT", coverage: 78, target: 85 },
-      ],
-    },
-  },
-  "rpt-anc-002": {
-    id: "rpt-anc-002",
-    reportType: "ANC_ATTENDANCE",
-    status: "QUEUED",
-    title: "ANC Attendance Report - 2024",
-    description: "Monthly antenatal care attendance trends",
-    generatedAt: "2024-06-15T14:30:00Z",
-    periodStart: "2024-01-01T00:00:00Z",
-    periodEnd: "2024-06-30T23:59:59Z",
-    facilityName: "Nyamata District Hospital",
-    data: {
-      monthlyAttendance: [
-        { month: "Jan", attendance: 342 },
-        { month: "Feb", attendance: 378 },
-        { month: "Mar", attendance: 395 },
-        { month: "Apr", attendance: 412 },
-        { month: "May", attendance: 438 },
-        { month: "Jun", attendance: 456 },
-      ],
-    },
-  },
-  "rpt-birth-003": {
-    id: "rpt-birth-003",
-    reportType: "BIRTH_REGISTRATION",
-    status: "PUSHED",
-    title: "Birth Registration Report - Q2 2024",
-    description: "Birth registrations by district",
-    generatedAt: "2024-07-01T09:00:00Z",
-    periodStart: "2024-04-01T00:00:00Z",
-    periodEnd: "2024-06-30T23:59:59Z",
-    districtName: "Bugesera District",
-    data: {
-      byDistrict: [
-        { district: "Nyamata", registrations: 523 },
-        { district: "Rweru", registrations: 312 },
-        { district: "Gashora", registrations: 418 },
-        { district: "Ntarama", registrations: 287 },
-        { district: "Mareba", registrations: 195 },
-        { district: "Rilima", registrations: 234 },
-      ],
-    },
-  },
-  "rpt-maternal-004": {
-    id: "rpt-maternal-004",
-    reportType: "MATERNAL_HEALTH",
-    status: "FAILED",
-    title: "Maternal Health Report - 2024",
-    description: "Key maternal health indicators and outcomes",
-    generatedAt: "2024-08-10T11:00:00Z",
-    periodStart: "2024-01-01T00:00:00Z",
-    periodEnd: "2024-07-31T23:59:59Z",
-    districtName: "Bugesera District",
-    data: {
-      stats: {
-        maternalMortalityProxy: 0.12,
-        ancCoverage: 89.5,
-        institutionalDeliveryRate: 91.2,
-      },
-    },
-  },
-};
+import { getGovReport, getGovReportsByUser } from "@/lib/api/government";
 
 /**
  * Custom hook for managing report data and operations
  */
 export function useReports(reportId: string) {
-  const [report, setReport] = useState<Report | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [pushing, setPushing] = useState(false);
-
-  // Fetch report data
-  const fetchReport = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    
-    try {
-      // Simulate API call delay
-      await new Promise((resolve) => setTimeout(resolve, 800));
-      
-      const mockReport = mockReports[reportId];
-      if (!mockReport) {
-        throw new Error("Report not found");
-      }
-      
-      setReport(mockReport);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to fetch report");
-    } finally {
-      setLoading(false);
-    }
-  }, [reportId]);
-
-  // Push report to HMIS
-  const pushToHmis = useCallback(async (): Promise<PushHmisResponse> => {
-    if (!report) {
-      throw new Error("No report to push");
-    }
-
-    setPushing(true);
-    
-    try {
-      // Simulate API call delay
-      await new Promise((resolve) => setTimeout(resolve, 1500));
-      
-      // Simulate random success/failure
-      const success = Math.random() > 0.2;
-      
-      if (success) {
-        // Update local state to reflect pushed status
-        setReport((prev) => prev ? { ...prev, status: "PUSHED" as ReportStatus } : null);
-        
-        return {
-          success: true,
-          message: "Report successfully pushed to HMIS",
-          pushedAt: new Date().toISOString(),
-        };
-      } else {
-        return {
-          success: false,
-          message: "Failed to push report to HMIS. Please try again.",
-        };
-      }
-    } catch (err) {
-      return {
-        success: false,
-        message: err instanceof Error ? err.message : "An error occurred while pushing",
-      };
-    } finally {
-      setPushing(false);
-    }
-  }, [report]);
-
-  // Initial fetch
-  useEffect(() => {
-    fetchReport();
-  }, [fetchReport]);
+  const reportQuery = useQuery({
+    queryKey: ["government", "reports", reportId],
+    queryFn: () => getGovReport(reportId),
+  });
 
   return {
-    report,
-    loading,
-    error,
-    pushing,
-    pushToHmis,
-    refetch: fetchReport,
+    report: reportQuery.data ?? null,
+    loading: reportQuery.isLoading,
+    error: reportQuery.error instanceof Error ? reportQuery.error.message : null,
+    refetch: reportQuery.refetch,
   };
 }
 
 /**
  * Hook to get all reports (for listing)
  */
-export function useReportList() {
-  const [reports, setReports] = useState<Report[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    const fetchReports = async () => {
-      setLoading(true);
-      setError(null);
-      
-      try {
-        // Simulate API call delay
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-        
-        // Return all mock reports as an array
-        setReports(Object.values(mockReports));
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to fetch reports");
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchReports();
-  }, []);
+export function useReportList(userId?: string) {
+  const reportListQuery = useQuery({
+    queryKey: ["government", "reports", "list", userId ?? "anonymous"],
+    queryFn: () => getGovReportsByUser(userId ?? ""),
+    enabled: Boolean(userId),
+  });
 
   return {
-    reports,
-    loading,
-    error,
+    reports: reportListQuery.data ?? [],
+    loading: reportListQuery.isLoading,
+    error: reportListQuery.error instanceof Error ? reportListQuery.error.message : null,
   };
 }
 

--- a/src/lib/api/government.ts
+++ b/src/lib/api/government.ts
@@ -1,4 +1,5 @@
 import { apiClient } from "@/lib/api/client";
+import type { Report, ReportStatus, ReportType } from "@/shared/types/report";
 
 export type GovSyncTargetSystem = "NIDA" | "HMIS" | "IREMBO";
 export type GovSyncStatus = "PENDING" | "IN_FLIGHT" | "SUCCEEDED" | "FAILED" | "DEAD_LETTER";
@@ -135,117 +136,24 @@ export type GovSyncRetryResult = {
   source: "api" | "demo";
 };
 
-const DEMO_STORAGE_KEY = "motherhood:gov-sync-logs-demo";
+export type GovReport = Report;
 
-function addMinutes(base: Date, minutes: number) {
-  const date = new Date(base);
-  date.setMinutes(date.getMinutes() + minutes);
-  return date.toISOString();
-}
+type ApiListResponse<T> = {
+  content?: T[];
+  data?: T[];
+  items?: T[];
+  logs?: T[];
+  reports?: T[];
+};
 
-function createDemoGovSyncLogs(): GovSyncLog[] {
-  const now = new Date();
+const GOV_REPORT_TYPES: ReportType[] = [
+  "VACCINATION_COVERAGE",
+  "ANC_ATTENDANCE",
+  "BIRTH_REGISTRATION",
+  "MATERNAL_HEALTH",
+];
 
-  return [
-    {
-      id: "742dfbd2-041b-4539-95ab-8e8b91317791",
-      createdAt: addMinutes(now, -6),
-      targetSystem: "HMIS",
-      syncType: "MATERNAL_VISIT_PUSH",
-      status: "IN_FLIGHT",
-      retryCount: 1,
-      lastErrorMessage: null,
-    },
-    {
-      id: "2a6c2c56-c0c2-4818-86f8-7c9df72ea861",
-      createdAt: addMinutes(now, -18),
-      targetSystem: "NIDA",
-      syncType: "NATIONAL_ID_LOOKUP",
-      status: "SUCCEEDED",
-      retryCount: 0,
-      lastErrorMessage: null,
-    },
-    {
-      id: "a2cbb6e9-0d7f-44ad-b13a-010e2b8bcb0c",
-      createdAt: addMinutes(now, -31),
-      targetSystem: "IREMBO",
-      syncType: "APPOINTMENT_NOTIFICATION",
-      status: "FAILED",
-      retryCount: 2,
-      lastErrorMessage:
-        "IREMBO gateway returned HTTP 503 after the appointment payload was accepted by the local queue.",
-    },
-    {
-      id: "c2b5e266-8b49-44f6-8500-a9f63e2d596c",
-      createdAt: addMinutes(now, -47),
-      targetSystem: "HMIS",
-      syncType: "DELIVERY_OUTCOME_PUSH",
-      status: "DEAD_LETTER",
-      retryCount: 5,
-      lastErrorMessage:
-        "HMIS rejected the delivery outcome because facilityCode was missing after all retry attempts.",
-    },
-    {
-      id: "ebb5e723-e3fc-40f2-9384-9d074f1377ad",
-      createdAt: addMinutes(now, -69),
-      targetSystem: "NIDA",
-      syncType: "MOTHER_DEMOGRAPHICS_VERIFY",
-      status: "PENDING",
-      retryCount: 0,
-      lastErrorMessage: null,
-    },
-  ];
-}
-
-function readStoredDemoGovSyncLogs(): GovSyncLog[] {
-  if (typeof window === "undefined") {
-    return createDemoGovSyncLogs();
-  }
-
-  try {
-    const raw = window.localStorage.getItem(DEMO_STORAGE_KEY);
-
-    if (!raw) {
-      const demo = createDemoGovSyncLogs();
-      window.localStorage.setItem(DEMO_STORAGE_KEY, JSON.stringify(demo));
-      return demo;
-    }
-
-    const parsed = JSON.parse(raw) as GovSyncLog[];
-    return Array.isArray(parsed) && parsed.length > 0 ? parsed : createDemoGovSyncLogs();
-  } catch {
-    return createDemoGovSyncLogs();
-  }
-}
-
-function writeStoredDemoGovSyncLogs(logs: GovSyncLog[]) {
-  if (typeof window === "undefined") {
-    return;
-  }
-
-  window.localStorage.setItem(DEMO_STORAGE_KEY, JSON.stringify(logs));
-}
-
-function appendDemoSyncLog() {
-  const startedAt = new Date().toISOString();
-  const currentLogs = readStoredDemoGovSyncLogs();
-  const newLog: GovSyncLog = {
-    id:
-      typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
-        ? crypto.randomUUID()
-        : `sync-${Date.now()}`,
-    createdAt: startedAt,
-    targetSystem: "HMIS",
-    syncType: "FULL_SYNC",
-    status: "IN_FLIGHT",
-    retryCount: 0,
-    lastErrorMessage: null,
-  };
-
-  writeStoredDemoGovSyncLogs([newLog, ...currentLogs]);
-
-  return { startedAt, id: newLog.id };
-}
+const GOV_REPORT_STATUSES: ReportStatus[] = ["NOT_PUSHED", "QUEUED", "PUSHED", "FAILED"];
 
 function normalizeTargetSystem(value: unknown): GovSyncTargetSystem {
   const normalized = String(value ?? "HMIS").toUpperCase();
@@ -265,6 +173,16 @@ function normalizeStatus(value: unknown): GovSyncStatus {
   }
 
   return "PENDING";
+}
+
+function normalizeReportType(value: unknown): ReportType | null {
+  const normalized = String(value ?? "").toUpperCase() as ReportType;
+  return GOV_REPORT_TYPES.includes(normalized) ? normalized : null;
+}
+
+function normalizeReportStatus(value: unknown): ReportStatus {
+  const normalized = String(value ?? "NOT_PUSHED").toUpperCase() as ReportStatus;
+  return GOV_REPORT_STATUSES.includes(normalized) ? normalized : "NOT_PUSHED";
 }
 
 function normalizeSyncLog(record: unknown): GovSyncLog | null {
@@ -310,40 +228,137 @@ function normalizeSyncLogResponse(response: unknown): GovSyncLog[] {
   return records.map(normalizeSyncLog).filter(Boolean) as GovSyncLog[];
 }
 
-export async function getGovSyncLogs(): Promise<GovSyncLog[]> {
-  try {
-    const response = await apiClient.get<unknown>("/api/v1/government/sync-logs");
-    const logs = normalizeSyncLogResponse(response);
-
-    if (logs.length > 0) {
-      return logs;
-    }
-  } catch {
-    // Keep the page usable while the backend endpoint is not available locally.
+function unwrapApiData<T>(response: unknown): T | null {
+  if (!response || typeof response !== "object") {
+    return null;
   }
 
-  return readStoredDemoGovSyncLogs();
+  const candidate = response as Record<string, unknown>;
+
+  if ("data" in candidate && candidate.data && typeof candidate.data === "object") {
+    return candidate.data as T;
+  }
+
+  return response as T;
+}
+
+function normalizeReport(record: unknown): GovReport | null {
+  if (!record || typeof record !== "object") {
+    return null;
+  }
+
+  const candidate = record as Record<string, unknown>;
+  const payload = candidate.data && typeof candidate.data === "object" ? (candidate.data as Record<string, unknown>) : candidate;
+  const reportType = normalizeReportType(payload.reportType ?? payload.report_type ?? candidate.reportType ?? candidate.report_type);
+
+  if (!reportType) {
+    return null;
+  }
+
+  const generatedAt = payload.generatedAt ?? payload.generated_at ?? candidate.generatedAt ?? candidate.generated_at;
+  const periodStart = payload.periodStart ?? payload.period_start ?? candidate.periodStart ?? candidate.period_start;
+  const periodEnd = payload.periodEnd ?? payload.period_end ?? candidate.periodEnd ?? candidate.period_end;
+  const data = payload.data ?? candidate.data ?? {};
+
+  return {
+    id: String(payload.id ?? candidate.id ?? ""),
+    reportType,
+    status: normalizeReportStatus(payload.status ?? candidate.status),
+    title: String(payload.title ?? candidate.title ?? `${reportType.replaceAll("_", " ")} Report`),
+    description: String(payload.description ?? candidate.description ?? ""),
+    generatedAt: typeof generatedAt === "string" ? generatedAt : new Date().toISOString(),
+    periodStart: typeof periodStart === "string" ? periodStart : new Date().toISOString(),
+    periodEnd: typeof periodEnd === "string" ? periodEnd : new Date().toISOString(),
+    facilityName: typeof payload.facilityName === "string" ? payload.facilityName : typeof candidate.facilityName === "string" ? candidate.facilityName : undefined,
+    districtName: typeof payload.districtName === "string" ? payload.districtName : typeof candidate.districtName === "string" ? candidate.districtName : undefined,
+    data: data as GovReport["data"],
+  };
+}
+
+function normalizeReportResponse(response: unknown): GovReport | null {
+  return normalizeReport(unwrapApiData<GovReport>(response));
+}
+
+function normalizeReportListResponse(response: unknown): GovReport[] {
+  const unwrapped = unwrapApiData<ApiListResponse<GovReport>>(response);
+
+  if (!unwrapped) {
+    return [];
+  }
+
+  const records = unwrapped.content ?? unwrapped.data ?? unwrapped.items ?? unwrapped.reports;
+
+  if (!Array.isArray(records)) {
+    return [];
+  }
+
+  return records.map(normalizeReport).filter(Boolean) as GovReport[];
+}
+
+export async function getGovSyncLogs(): Promise<GovSyncLog[]> {
+  try {
+    const response = await apiClient.get<unknown>("/api/v1/admin/gov-sync?page=0&size=200");
+    return normalizeSyncLogResponse(response);
+  } catch (error) {
+    throw error instanceof Error ? error : new Error("Failed to load sync logs");
+  }
+}
+
+export async function getGovDeadLetterLogs(): Promise<GovSyncLog[]> {
+  try {
+    const response = await apiClient.get<unknown>("/api/v1/admin/gov-sync/dead-letter");
+    return normalizeSyncLogResponse(response);
+  } catch (error) {
+    throw error instanceof Error ? error : new Error("Failed to load dead-letter queue");
+  }
+}
+
+export async function getGovSyncStatus(): Promise<Record<string, number>> {
+  try {
+    const response = await apiClient.get<unknown>("/api/v1/admin/gov-sync/status");
+    const data = unwrapApiData<Record<string, unknown>>(response);
+
+    if (!data) {
+      return {};
+    }
+
+    return Object.entries(data).reduce<Record<string, number>>((accumulator, [key, value]) => {
+      accumulator[key] = Number(value ?? 0);
+      return accumulator;
+    }, {});
+  } catch (error) {
+    throw error instanceof Error ? error : new Error("Failed to load sync status");
+  }
 }
 
 export async function triggerFullSync(): Promise<GovSyncTriggerResult> {
   try {
-    const response = await apiClient.post<unknown>("/api/v1/government/sync");
+    await apiClient.post("/api/v1/government/sync");
     return { status: "started", source: "api", startedAt: new Date().toISOString() };
-  } catch {
-    // In demo mode, record a sync entry so the action has a visible effect.
-    const { startedAt } = appendDemoSyncLog();
-    return { status: "started", source: "demo", startedAt };
+  } catch (error) {
+    throw error instanceof Error ? error : new Error("Failed to start full sync");
   }
 }
 
 export async function exportGovData(format = "csv"): Promise<{ filename: string; content: string } | null> {
   try {
-    // Attempt to fetch export as text (backend should supply CSV/TXT)
-    const data = await apiClient.get<string>(`/api/v1/government/export?format=${encodeURIComponent(format)}`);
-    const filename = `gov-export.${format}`;
-    return { filename, content: String(data ?? "") };
+    const response = await apiClient.get<unknown>(`/api/v1/government/export?format=${encodeURIComponent(format)}`);
+
+    if (typeof response === "string") {
+      return { filename: `gov-export.${format}`, content: response };
+    }
+
+    if (response && typeof response === "object") {
+      const candidate = response as Record<string, unknown>;
+      const content = candidate.content ?? candidate.data ?? candidate.text ?? candidate.csv;
+
+      if (typeof content === "string") {
+        return { filename: `gov-export.${format}`, content };
+      }
+    }
+
+    return null;
   } catch {
-    // No backend — return null to indicate demo/no-op
     return null;
   }
 }
@@ -352,18 +367,23 @@ export async function retryGovSyncLog(id: string): Promise<GovSyncRetryResult> {
   try {
     await apiClient.post(`/api/v1/government/sync-logs/${id}/retry`);
     return { id, status: "PENDING", source: "api" };
-  } catch {
-    const updated = readStoredDemoGovSyncLogs().map((log) =>
-      log.id === id
-        ? {
-            ...log,
-            status: "PENDING" as GovSyncStatus,
-            retryCount: log.retryCount + 1,
-            lastErrorMessage: null,
-          }
-        : log,
-    );
-    writeStoredDemoGovSyncLogs(updated);
-    return { id, status: "PENDING", source: "demo" };
+  } catch (error) {
+    throw error instanceof Error ? error : new Error("Failed to retry sync log");
   }
+}
+
+export async function getGovReport(reportId: string): Promise<GovReport> {
+  const response = await apiClient.get<unknown>(`/api/v1/gov-reports/${reportId}`);
+  const report = normalizeReportResponse(response);
+
+  if (!report) {
+    throw new Error(`Report ${reportId} was returned in an unexpected format`);
+  }
+
+  return report;
+}
+
+export async function getGovReportsByUser(userId: string): Promise<GovReport[]> {
+  const response = await apiClient.get<unknown>(`/api/v1/gov-reports/by-user/${userId}?page=0&size=50`);
+  return normalizeReportListResponse(response);
 }

--- a/src/lib/api/government.ts
+++ b/src/lib/api/government.ts
@@ -1,6 +1,14 @@
 import { apiClient } from "@/lib/api/client";
 import type { Report, ReportStatus, ReportType } from "@/shared/types/report";
 
+export type GovReportRequest = {
+  reportType: ReportType;
+  period: string;
+  scopeLevel: string;
+  geoLocationId: string;
+  aggregates: Record<string, unknown>;
+};
+
 export type GovSyncTargetSystem = "NIDA" | "HMIS" | "IREMBO";
 export type GovSyncStatus = "PENDING" | "IN_FLIGHT" | "SUCCEEDED" | "FAILED" | "DEAD_LETTER";
 
@@ -100,6 +108,20 @@ function generateMockDashboardData(
   };
 }
 
+function getRecordValue(record: Record<string, unknown>, keys: string[]): unknown {
+  for (const key of keys) {
+    if (key in record) {
+      return record[key];
+    }
+  }
+
+  return undefined;
+}
+
+function normalizePeriodLabel(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
 export async function getNationalDashboardMetrics(
   metric: DashboardMetric,
   period: string,
@@ -175,6 +197,24 @@ function normalizeStatus(value: unknown): GovSyncStatus {
   return "PENDING";
 }
 
+function normalizeGovReportStatus(value: unknown): ReportStatus {
+  const normalized = String(value ?? "").toUpperCase();
+
+  if (normalized === "IN_FLIGHT" || normalized === "QUEUED") {
+    return "QUEUED";
+  }
+
+  if (normalized === "SUCCEEDED" || normalized === "PUSHED") {
+    return "PUSHED";
+  }
+
+  if (normalized === "FAILED" || normalized === "DEAD_LETTER") {
+    return "FAILED";
+  }
+
+  return "NOT_PUSHED";
+}
+
 function normalizeReportType(value: unknown): ReportType | null {
   const normalized = String(value ?? "").toUpperCase() as ReportType;
   return GOV_REPORT_TYPES.includes(normalized) ? normalized : null;
@@ -228,6 +268,66 @@ function normalizeSyncLogResponse(response: unknown): GovSyncLog[] {
   return records.map(normalizeSyncLog).filter(Boolean) as GovSyncLog[];
 }
 
+function normalizeMeProfileId(response: unknown): string | null {
+  const unwrapped = unwrapApiData<Record<string, unknown>>(response);
+
+  if (!unwrapped) {
+    return null;
+  }
+
+  const profile = "data" in unwrapped && unwrapped.data && typeof unwrapped.data === "object"
+    ? (unwrapped.data as Record<string, unknown>)
+    : unwrapped;
+  const id = getRecordValue(profile, ["id", "userId", "uuid"]);
+
+  return typeof id === "string" && id ? id : null;
+}
+
+export type GovernmentProfile = {
+  id: string;
+  geoLocationId: string | null;
+};
+
+function normalizeGovernmentProfile(response: unknown): GovernmentProfile | null {
+  const unwrapped = unwrapApiData<Record<string, unknown>>(response);
+
+  if (!unwrapped) {
+    return null;
+  }
+
+  const profile = "data" in unwrapped && unwrapped.data && typeof unwrapped.data === "object"
+    ? (unwrapped.data as Record<string, unknown>)
+    : unwrapped;
+  const id = getRecordValue(profile, ["id", "userId", "uuid"]);
+  const geoLocationId = getRecordValue(profile, ["geoLocationId", "geo_location_id"]);
+
+  if (typeof id !== "string" || !id) {
+    return null;
+  }
+
+  return {
+    id,
+    geoLocationId: typeof geoLocationId === "string" && geoLocationId ? geoLocationId : null,
+  };
+}
+
+function normalizeReportPeriod(report: Record<string, unknown>): string {
+  const period = normalizePeriodLabel(getRecordValue(report, ["period"]));
+
+  if (period) {
+    return period;
+  }
+
+  const periodStart = normalizePeriodLabel(getRecordValue(report, ["periodStart", "period_start"]));
+  const periodEnd = normalizePeriodLabel(getRecordValue(report, ["periodEnd", "period_end"]));
+
+  if (periodStart && periodEnd) {
+    return `${periodStart} - ${periodEnd}`;
+  }
+
+  return periodStart ?? periodEnd ?? new Date().toISOString();
+}
+
 function unwrapApiData<T>(response: unknown): T | null {
   if (!response || typeof response !== "object") {
     return null;
@@ -249,29 +349,44 @@ function normalizeReport(record: unknown): GovReport | null {
 
   const candidate = record as Record<string, unknown>;
   const payload = candidate.data && typeof candidate.data === "object" ? (candidate.data as Record<string, unknown>) : candidate;
-  const reportType = normalizeReportType(payload.reportType ?? payload.report_type ?? candidate.reportType ?? candidate.report_type);
+  const reportType = normalizeReportType(
+    getRecordValue(payload, ["reportType", "report_type"]) ?? getRecordValue(candidate, ["reportType", "report_type"]),
+  );
 
   if (!reportType) {
     return null;
   }
 
-  const generatedAt = payload.generatedAt ?? payload.generated_at ?? candidate.generatedAt ?? candidate.generated_at;
-  const periodStart = payload.periodStart ?? payload.period_start ?? candidate.periodStart ?? candidate.period_start;
-  const periodEnd = payload.periodEnd ?? payload.period_end ?? candidate.periodEnd ?? candidate.period_end;
-  const data = payload.data ?? candidate.data ?? {};
+  const generatedAt = getRecordValue(payload, ["generatedAt", "generated_at"]) ?? getRecordValue(candidate, ["generatedAt", "generated_at"]);
+  const period = normalizeReportPeriod(payload);
+  const aggregates = getRecordValue(payload, ["aggregates", "data"]) ?? getRecordValue(candidate, ["aggregates", "data"]);
+  const scopeLevel = getRecordValue(payload, ["scopeLevel", "scope_level", "scope"]);
+  const geoLocationId = getRecordValue(payload, ["geoLocationId", "geo_location_id"]);
+  const generatedById = getRecordValue(payload, ["generatedById", "generated_by_id"]);
+  const hmisPushStatus = getRecordValue(payload, ["hmisPushStatus", "hmis_push_status"]);
 
   return {
     id: String(payload.id ?? candidate.id ?? ""),
     reportType,
-    status: normalizeReportStatus(payload.status ?? candidate.status),
+    status: normalizeGovReportStatus(hmisPushStatus ?? payload.status ?? candidate.status),
     title: String(payload.title ?? candidate.title ?? `${reportType.replaceAll("_", " ")} Report`),
-    description: String(payload.description ?? candidate.description ?? ""),
+    description: String(
+      payload.description ??
+        candidate.description ??
+        `${reportType.replaceAll("_", " ")} analytics for ${String(scopeLevel ?? "national").toLowerCase()}`,
+    ),
     generatedAt: typeof generatedAt === "string" ? generatedAt : new Date().toISOString(),
-    periodStart: typeof periodStart === "string" ? periodStart : new Date().toISOString(),
-    periodEnd: typeof periodEnd === "string" ? periodEnd : new Date().toISOString(),
+    period,
+    scopeLevel: typeof scopeLevel === "string" ? scopeLevel : undefined,
+    generatedById: typeof generatedById === "string" ? generatedById : undefined,
+    geoLocationId: typeof geoLocationId === "string" ? geoLocationId : undefined,
+    hmisPushStatus: typeof hmisPushStatus === "string" ? hmisPushStatus : undefined,
+    periodStart: period,
+    periodEnd: period,
     facilityName: typeof payload.facilityName === "string" ? payload.facilityName : typeof candidate.facilityName === "string" ? candidate.facilityName : undefined,
     districtName: typeof payload.districtName === "string" ? payload.districtName : typeof candidate.districtName === "string" ? candidate.districtName : undefined,
-    data: data as GovReport["data"],
+    data: aggregates as GovReport["data"],
+    aggregates: aggregates as Record<string, unknown>,
   };
 }
 
@@ -280,19 +395,45 @@ function normalizeReportResponse(response: unknown): GovReport | null {
 }
 
 function normalizeReportListResponse(response: unknown): GovReport[] {
-  const unwrapped = unwrapApiData<ApiListResponse<GovReport>>(response);
+  const unwrapped = unwrapApiData<ApiListResponse<GovReport> | Record<string, unknown>>(response);
 
   if (!unwrapped) {
     return [];
   }
 
-  const records = unwrapped.content ?? unwrapped.data ?? unwrapped.items ?? unwrapped.reports;
+  const candidate = unwrapped as Record<string, unknown>;
+  const nestedData = candidate.data && typeof candidate.data === "object" ? (candidate.data as Record<string, unknown>) : null;
+  const records =
+    (Array.isArray((candidate as ApiListResponse<GovReport>).content) && (candidate as ApiListResponse<GovReport>).content) ||
+    (Array.isArray(candidate.content) && candidate.content) ||
+    (Array.isArray(candidate.items) && candidate.items) ||
+    (Array.isArray(candidate.reports) && candidate.reports) ||
+    (nestedData && (Array.isArray(nestedData.content) ? nestedData.content : Array.isArray(nestedData.items) ? nestedData.items : Array.isArray(nestedData.reports) ? nestedData.reports : null)) ||
+    (nestedData && Array.isArray(nestedData.data) ? nestedData.data : null);
 
   if (!Array.isArray(records)) {
     return [];
   }
 
   return records.map(normalizeReport).filter(Boolean) as GovReport[];
+}
+
+export async function getCurrentGovernmentUserId(): Promise<string | null> {
+  try {
+    const response = await apiClient.get<unknown>("/api/v1/me");
+    return normalizeMeProfileId(response);
+  } catch {
+    return null;
+  }
+}
+
+export async function getCurrentGovernmentProfile(): Promise<GovernmentProfile | null> {
+  try {
+    const response = await apiClient.get<unknown>("/api/v1/me");
+    return normalizeGovernmentProfile(response);
+  } catch {
+    return null;
+  }
 }
 
 export async function getGovSyncLogs(): Promise<GovSyncLog[]> {
@@ -386,4 +527,15 @@ export async function getGovReport(reportId: string): Promise<GovReport> {
 export async function getGovReportsByUser(userId: string): Promise<GovReport[]> {
   const response = await apiClient.get<unknown>(`/api/v1/gov-reports/by-user/${userId}?page=0&size=50`);
   return normalizeReportListResponse(response);
+}
+
+export async function generateGovReport(request: GovReportRequest): Promise<GovReport> {
+  const response = await apiClient.post<unknown>("/api/v1/gov-reports", request);
+  const report = normalizeReportResponse(response);
+
+  if (!report) {
+    throw new Error("Government report generation returned an unexpected format");
+  }
+
+  return report;
 }

--- a/src/shared/types/report.ts
+++ b/src/shared/types/report.ts
@@ -81,11 +81,17 @@ export interface Report {
   title: string;
   description: string;
   generatedAt: string;
+  period?: string;
+  scopeLevel?: string;
+  generatedById?: string;
+  geoLocationId?: string;
+  hmisPushStatus?: string;
   periodStart: string;
   periodEnd: string;
   facilityName?: string;
   districtName?: string;
   data: ReportData[ReportType];
+  aggregates?: Record<string, unknown>;
 }
 
 /**


### PR DESCRIPTION
This PR wires the frontend Government Reports UI to the backend Gov Reports API, replaces mock/demo data, and adds normalization/types/hooks.

Files changed: src/lib/api/government.ts, src/hooks/useReports.ts, src/shared/types/report.ts, src/app/reports/* and related components.

@Derrick-MUGISHA please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added local JSON export capability for reports
  * Dead-letter queue and detailed sync status (Pending, In-flight, Dead-letter) now visible in sync logs
  * Backend-backed report generation with configurable JSON aggregates

* **Improvements**
  * Dynamic report listings now sourced from API instead of hardcoded data
  * Enhanced report data handling with improved type safety
  * Updated sync log summary metrics and retry mechanics

* **Bug Fixes**
  * Removed non-functional government "Push to HMIS" integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->